### PR TITLE
Proposed patch for Ultimate Category Excluder to disable functionality when API requests are handled

### DIFF
--- a/ultimate-category-excluder.php
+++ b/ultimate-category-excluder.php
@@ -33,6 +33,22 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 add_action( 'admin_menu', 'ksuce_admin_menu' );
 add_filter( 'pre_get_posts','ksuce_exclude_categories' );
 
+// Monitor XMLRPC and REST queries to disable plugin functionality during API requests. This
+// ensures that REST and XMLRPC clients see the complete content of the blog for admin purposes.
+$ksuce_is_api_query = false;
+add_action( 'xmlrpc_call', 'ksuce_detect_xmlrpc_api' );
+add_action( 'rest_api_init', 'ksuce_detect_rest_api' );
+
+function ksuce_detect_xmlrpc_api() {
+	global $ksuce_is_api_query;
+	$ksuce_is_api_query = true;
+}
+
+function ksuce_detect_rest_api() {
+	global $ksuce_is_api_query;
+	$ksuce_is_api_query = true;
+}
+
 // Include Ultimate Category Excluder language files
 load_plugin_textdomain( 'ultimate-category-excluder', false, dirname(plugin_basename(__FILE__)) . '/languages' );
 
@@ -96,6 +112,7 @@ function ksuce_options_page() {
 		</tr>			
 	<?php } ?>
 	</table>
+	<p><input type="checkbox" name="disable_for_api" id="disable_for_api" <?php if ($options['disable_for_api'] == true) { echo 'checked="true" '; } ?>/><label for="disable-for-xmlrpc"><?php _e( 'Disable category exclusion for authenticated API requests', 'ultimate-category-excluder' ); ?></label></p>
 	<p class="submit"><input type="submit" value="<?php _e('Update', 'ultimate-category-excluder'); ?>" /></p>
 	<input type="hidden" name="ksuce" value="true" />
 	</form>
@@ -124,10 +141,14 @@ function ksuce_process() {
 	if( !isset( $_POST[ 'exclude_feed' ] ) )     { $_POST[ 'exclude_feed' ] = array(); }
 	if( !isset( $_POST[ 'exclude_archives' ] ) ) { $_POST[ 'exclude_archives' ] = array(); }
 	if( !isset( $_POST[ 'exclude_search' ] ) )   { $_POST[ 'exclude_search' ] = array(); }
+	if( !isset( $_POST[ 'disable_for_api' ] ) )   { $_POST[ 'disable_for_api' ] = false; }
+
 	$options['exclude_main'] = $_POST[ 'exclude_main' ];
 	$options['exclude_feed'] = $_POST[ 'exclude_feed' ];
 	$options['exclude_archives'] = $_POST[ 'exclude_archives' ];
 	$options['exclude_search'] = $_POST[ 'exclude_search' ];
+	$options['disable_for_api'] = $_POST[ 'disable_for_api' ];
+
 	update_option( 'ksuceExcludes', $options );
 	$message = "<div class='updated'><p>" . ( __( 'Excludes successfully updated', 'ultimate-category-excluder' ) ) . "</p></div>";
 	return $message;
@@ -139,9 +160,18 @@ function ksuce_get_options(){
 	$defaults['exclude_feed'] = array();
 	$defaults['exclude_archives'] = array();
 	$defaults['exclude_search'] = array();
+	$defaults['disable_for_api'] = true;
+
 	$options = get_option( 'ksuceExcludes' );
 	if ( !is_array( $options ) ){
 		$options = $defaults;
+		update_option( 'ksuceExcludes', $options );
+	}
+
+	// If the array exists but doesn't have a value for disable_for_api,
+	// default to false to ensure existing users have to opt in to new behavior.
+	if ( array_key_exists('disable_for_api', $options) == false ){
+		$options['disable_for_api'] = false;
 		update_option( 'ksuceExcludes', $options );
 	}
 	return $options;
@@ -152,6 +182,9 @@ function ksuce_exclude_categories( $query ) {
 	$array2[0] = "";
 	unset( $array2[0] );
 	$options = ksuce_get_options();
+
+	global $ksuce_is_api_query;
+	if ( ($options['disable_for_api'] == true) && $ksuce_is_api_query && is_user_logged_in() ) { return $query; }
 
 	//wp_reset_query();
 	//error_log( print_r( debug_backtrace(), true ) );
@@ -214,4 +247,4 @@ function in_array_recursive( $needle, $haystack ) {
 
 	return $found;
 } 
-?>
+?>


### PR DESCRIPTION
Add a new setting for limiting the effect of the plugin when an authenticated XMLRPC or REST API request is being handled. Default this setting to ON for all new users, but to OFF for all existing users.